### PR TITLE
chore(client/config): add @ path alias for src directory

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,8 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import Layout from './components/layout/Layout';
-import HomePage from './pages/Home';
-import Login from './pages/Login';
+
+import Layout from '@/components/layout/Layout';
+import HomePage from '@/pages/Home';
+import Login from '@/pages/Login';
 
 const router = createBrowserRouter([
   {

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import Logo from '../Logo';
+import Logo from '@/components/Logo';
 
 export default function Header() {
   return (

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 
-import Header from './Header';
-import Footer from './Footer';
+import Header from '@/components/layout/Header';
+import Footer from '@/components/layout/Footer';
 
 export default function Layout() {
   return (

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -32,7 +32,13 @@
     "alwaysStrict": true,
     "noImplicitReturns": true,
     "exactOptionalPropertyTypes": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+
+    /* Path alias */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
 });


### PR DESCRIPTION
# Add @ path alias for src directory

## What this PR does
This PR configures path aliases in our project to improve code readability and maintainability by eliminating deep relative import paths.

## Why it's needed
- Simplifies import statements by replacing complex relative paths (../../components/Button) with cleaner aliases (@/components/Button)
- Makes refactoring easier since moving files doesn't break import paths
- Improves developer experience and reduces cognitive load when navigating the codebase

## Implementation
- Updated tsconfig.app.json to add paths configuration
- Modified vite.config.ts to configure path resolution