### PR TITLE
fix(schema/auth): Removal of createdAt and updateAt fields

### DIFF
--- a/client/src/schemas/auth.schema.ts
+++ b/client/src/schemas/auth.schema.ts
@@ -12,8 +12,6 @@ export const LOGIN_MUTATION = gql`
         role
         service
         status
-        createdAt
-        updatedAt
       }
     }
   }


### PR DESCRIPTION
This pull request includes a small change to the `LOGIN_MUTATION` in `client/src/schemas/auth.schema.ts`. The change removes the `createdAt` and `updatedAt` fields from the mutation response.