### PR TITLE
feat(me): Add 'me' query

### DIFF
--- a/client/src/contexts/auth.context.tsx
+++ b/client/src/contexts/auth.context.tsx
@@ -1,5 +1,5 @@
-import { createContext, useState, ReactNode } from 'react';
-import { useLoginMutation, User } from '@/types/graphql-generated';
+import { createContext, useState, ReactNode, useEffect } from 'react';
+import { useLoginMutation, useMeQuery, User } from '@/types/graphql-generated';
 
 export type AuthContextType = {
   user: User | null;
@@ -17,6 +17,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
 
   const [loginMutation] = useLoginMutation();
+  const { data: meData } = useMeQuery();
+
+  useEffect(() => {
+    if (!meData) return;
+    const fetchUser = async () => {
+      setUser(meData.me as User);
+      setIsLoading(false);
+    };
+    fetchUser();
+  }, [meData]);
 
   const login = async (email: string, password: string) => {
     setIsLoading(true);

--- a/client/src/schemas/auth.schema.ts
+++ b/client/src/schemas/auth.schema.ts
@@ -18,3 +18,17 @@ export const LOGIN_MUTATION = gql`
     }
   }
 `;
+
+export const ME_QUERY = gql`
+  query Me {
+    me {
+      id
+      email
+      firstname
+      lastname
+      role
+      service
+      status
+    }
+  }
+`;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -22,7 +22,7 @@ async function startServer() {
 
   const { url } = await startStandaloneServer(server, {
     listen: { port: parseInt(process.env.PORT as string) || 4000 },
-    context: async ({ res }) => ({ res }),
+    context: async ({ req, res }) => ({ req, res }),
   });
 
   console.info(`🚀 Server ready at ${url}`);


### PR DESCRIPTION
This pull request introduces a "current user" (`me`) feature to both the client and server, enabling user authentication state to be persisted and retrieved. Key changes include adding a `me` query on the client and server, updating the API context to include request data, and modifying the `AuthProvider` to utilize the new query for user state management.

### Client-Side Changes:

* **Added `me` query to fetch current user data:**
  - Introduced the `useMeQuery` hook in `AuthProvider` to retrieve and set the authenticated user's data on load. (`client/src/contexts/auth.context.tsx`, [[1]](diffhunk://#diff-09daabaaa3f0e7d7b97a11227d551cc94855c3a154eb49607ca9db0937102291L1-R2) [[2]](diffhunk://#diff-09daabaaa3f0e7d7b97a11227d551cc94855c3a154eb49607ca9db0937102291R20-R29)
  - Defined the `ME_QUERY` in `auth.schema.ts` to structure the GraphQL query for fetching the current user. (`client/src/schemas/auth.schema.ts`, [client/src/schemas/auth.schema.tsR19-R32](diffhunk://#diff-4fcb76563423698b335189575cc08ab27244ad077cb2e03805a0c9d86c534cd4R19-R32))

### Server-Side Changes:

* **Enhanced GraphQL API to support `me` query:**
  - Added a `me` query resolver in `AuthResolver` to return the authenticated user based on the token in cookies. (`server/src/resolvers/auth.resolver.ts`, [server/src/resolvers/auth.resolver.tsR35-R67](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22R35-R67))
  - Updated imports in `AuthResolver` to include `Query` and `Request`. (`server/src/resolvers/auth.resolver.ts`, [server/src/resolvers/auth.resolver.tsL2-R7](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L2-R7))

* **Updated server context to include request object:**
  - Modified the Apollo server context to pass the `req` object, enabling access to cookies for authentication. (`server/src/index.ts`, [server/src/index.tsL25-R25](diffhunk://#diff-c299744f73df4daa7a22854dda2023b68bfc8a5d59d8fb90b3a53b0c2842d807L25-R25))