### PR TITLE
feat(server/planning): Add planning entity

### DIFF
--- a/server/src/database/client.ts
+++ b/server/src/database/client.ts
@@ -1,6 +1,7 @@
 import { DataSource } from 'typeorm';
 
 import { User } from '../entities/user.entity';
+import { Planning } from '../entities/planning.entity';
 
 import 'dotenv/config';
 
@@ -11,7 +12,7 @@ export const dataSource = new DataSource({
   username: process.env.DB_USERNAME || 'postgres',
   password: process.env.DB_PASSWORD || 'postgres',
   database: process.env.DB_DATABASE || 'doctoplan',
-  entities: [User],
+  entities: [User, Planning],
   synchronize: true,
   logging: true,
 });

--- a/server/src/entities/planning.entity.ts
+++ b/server/src/entities/planning.entity.ts
@@ -1,4 +1,4 @@
-import { BaseEntity, Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Field, ID, ObjectType } from 'type-graphql';
 import { User } from './user.entity';
 
@@ -66,19 +66,13 @@ export class Planning extends BaseEntity {
   sunday_end: string;
 
   @Field(() => User)
-  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @ManyToOne(() => User, (user) => user.plannings)
   @JoinColumn({ name: 'user_id' })
   user: User;
 
-  @Field()
-  @Column()
-  user_id: number;
-
-  @Field()
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
   createdAt: Date;
 
-  @Field()
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
   updatedAt: Date;
 }

--- a/server/src/entities/planning.entity.ts
+++ b/server/src/entities/planning.entity.ts
@@ -1,0 +1,84 @@
+import { BaseEntity, Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Field, ID, ObjectType } from 'type-graphql';
+import { User } from './user.entity';
+
+@ObjectType()
+@Entity()
+export class Planning extends BaseEntity {
+  @Field(() => ID)
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  start: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  end: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  monday_start: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  monday_end: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  tuesday_start: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  tuesday_end: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  wednesday_start: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  wednesday_end: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  thursday_start: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  thursday_end: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  saturday_start: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  saturday_end: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  sunday_start: string;
+
+  @Field(() => String, { nullable: true })
+  @Column({ type: 'time', nullable: true })
+  sunday_end: string;
+
+  @Field(() => User)
+  @OneToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @Field()
+  @Column()
+  user_id: number;
+
+  @Field()
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+
+  @Field()
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP', onUpdate: 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+}

--- a/server/src/entities/user.entity.ts
+++ b/server/src/entities/user.entity.ts
@@ -1,5 +1,6 @@
-import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { Field, ID, ObjectType } from 'type-graphql';
+import { Planning } from './planning.entity';
 
 export enum UserRole {
   ADMIN = 'admin',
@@ -55,6 +56,10 @@ export class User extends BaseEntity {
     default: UserStatus.PENDING,
   })
   status: UserStatus;
+
+  @Field(() => [Planning], { nullable: true })
+  @OneToMany(() => Planning, (planning) => planning.user)
+  plannings: Planning[];
 
   @Field()
   @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })


### PR DESCRIPTION
This pull request introduces a new `Planning` entity to the database and integrates it into the existing system. The changes include defining the `Planning` entity with its fields, adding it to the database configuration, and establishing a relationship with the `User` entity.

### Database Integration:
* Added the `Planning` entity to the `entities` array in the database configuration, enabling it to be managed by TypeORM. (`server/src/database/client.ts`, [[1]](diffhunk://#diff-40fd6ec4a7667111eff9f15a0d541703652550e68fccf8a4880a4e9f606cac25R4) [[2]](diffhunk://#diff-40fd6ec4a7667111eff9f15a0d541703652550e68fccf8a4880a4e9f606cac25L14-R15)

### New Entity Definition:
* Created the `Planning` entity with fields for daily start and end times, a one-to-one relationship with the `User` entity, and timestamps for creation and updates. (`server/src/entities/planning.entity.ts`, [server/src/entities/planning.entity.tsR1-R84](diffhunk://#diff-18771b83baf878f8ef78badbbab22793472d6613d6a2d9869a1eda3754fc6c98R1-R84))