### PR TITLE
chore(workflows/lint-test): Add linter test to workflows

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,75 @@
+name: Lint and Format
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  lint-client:
+    name: Lint Client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm run install:client
+
+      - name: Run ESLint
+        run: npm run lint:client
+
+  lint-server:
+    name: Lint Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm run install:server
+
+      - name: Run ESLint
+        run: npm run lint:server
+
+  format-check:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm run install:client
+          npm run install:server
+
+      - name: Check Client Formatting
+        run: npm run format:client
+
+      - name: Check Server Formatting
+        run: npm run format:server

--- a/client/src/contexts/AuthContext.ts
+++ b/client/src/contexts/AuthContext.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+import { User } from '@/types/graphql-generated';
+
+export type AuthContextType = {
+  user: User | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  error: string | null;
+  login: (email: string, password: string) => Promise<void>;
+};
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate linting and formatting checks for both the client and server codebases. The workflow is triggered on pushes and pull requests to the `main` and `dev` branches.

### New GitHub Actions Workflow:
* `.github/workflows/lint-test.yml`: Added a workflow named "Lint and Format" with three jobs:
  - **Lint Client**: Runs ESLint on the client codebase after setting up Node.js and installing dependencies.
  - **Lint Server**: Runs ESLint on the server codebase after setting up Node.js and installing dependencies.
  - **Format Check**: Checks code formatting for both client and server using the respective formatting scripts.