### PR TITLE
chore(*/package): Non-warning policy added for eslint

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint . --fix",
-    "lint:file": "eslint",
+    "lint:file": "eslint --max-warnings=0",
     "preview": "vite preview",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
     "seed": "ts-node src/database/seed.ts",
     "lint": "eslint --config eslint.config.mjs . --ext .ts",
     "lint:fix": "eslint --config eslint.config.mjs . --ext .ts --fix",
-    "lint:file": "eslint --config eslint.config.mjs",
+    "lint:file": "eslint --config eslint.config.mjs --max-warnings=0",
     "format": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "format:file": "prettier --check"


### PR DESCRIPTION
This pull request updates the linting scripts in both the client and server `package.json` files to enforce stricter linting rules by setting `--max-warnings=0` for the `lint:file` command.

Linting script updates:

* [`client/package.json`](diffhunk://#diff-1846122c2c83a486a3693f7966aa522c34cf489f674185c4da0d9221683fd81fL11-R11): Modified the `lint:file` script to include the `--max-warnings=0` flag, ensuring no warnings are allowed during linting.
* [`server/package.json`](diffhunk://#diff-da00458cdaeaea2314cb0e0101c85130593048072ada62de01727958c5d6ca37L12-R12): Updated the `lint:file` script to add the `--max-warnings=0` flag, aligning with stricter linting requirements.