### PR TITLE
fix(login): Fix service issue

### DIFF
--- a/client/src/schemas/auth.schema.ts
+++ b/client/src/schemas/auth.schema.ts
@@ -9,8 +9,10 @@ export const LOGIN_MUTATION = gql`
         email
         firstname
         lastname
+        departement {
+          label
+        }
         role
-        service
         status
       }
     }
@@ -24,8 +26,10 @@ export const ME_QUERY = gql`
       email
       firstname
       lastname
+      departement {
+        label
+      }
       role
-      service
       status
     }
   }

--- a/server/src/resolvers/auth.resolver.ts
+++ b/server/src/resolvers/auth.resolver.ts
@@ -13,7 +13,10 @@ export class AuthResolver {
     @Arg('input') input: LoginInput,
     @Ctx() context: { res: Response },
   ): Promise<AuthResponse> {
-    const user = await User.findOne({ where: { email: input.email } });
+    const user = await User.findOne({
+      where: { email: input.email },
+      relations: ['departement'],
+    });
     if (!user) {
       throw new Error('Invalid email or password');
     }
@@ -57,7 +60,10 @@ export class AuthResolver {
 
       const decoded = verifyToken(token);
 
-      const user = await User.findOne({ where: { id: decoded.id } });
+      const user = await User.findOne({
+        where: { id: decoded.id },
+        relations: ['departement'],
+      });
 
       return user;
     } catch (error) {


### PR DESCRIPTION
This pull request introduces updates to the authentication schema and resolver to include a new `departement` field while removing the `service` field. The changes ensure that the `departement` data is both fetched and exposed in GraphQL queries and mutations.

### Schema updates:

* [`client/src/schemas/auth.schema.ts`](diffhunk://#diff-4fcb76563423698b335189575cc08ab27244ad077cb2e03805a0c9d86c534cd4R12-L13): Added the `departement` field with a `label` subfield to the `LOGIN_MUTATION` and `ME_QUERY` GraphQL operations. Removed the `service` field from both operations. [[1]](diffhunk://#diff-4fcb76563423698b335189575cc08ab27244ad077cb2e03805a0c9d86c534cd4R12-L13) [[2]](diffhunk://#diff-4fcb76563423698b335189575cc08ab27244ad077cb2e03805a0c9d86c534cd4R29-L28)

### Resolver updates:

* [`server/src/resolvers/auth.resolver.ts`](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L16-R19): Updated the `AuthResolver` to include the `departement` relation when querying the `User` entity in both the `login` and `me` methods. This ensures the `departement` data is fetched from the database. [[1]](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L16-R19) [[2]](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L60-R66)