### PR TITLE
fix(server/jest): Fix departement creation

### DIFF
--- a/server/jest.setup.ts
+++ b/server/jest.setup.ts
@@ -2,7 +2,7 @@ import argon2 from 'argon2';
 import { beforeAll, afterAll } from '@jest/globals';
 
 import { dataSource } from './src/database/client';
-import { Departement } from './src/entities/departement.entity';
+import { Departement, DepartementStatus } from './src/entities/departement.entity';
 import { User } from './src/entities/user.entity';
 
 beforeAll(async () => {
@@ -11,6 +11,10 @@ beforeAll(async () => {
 
     const departement = await Departement.insert({
       label: 'Test',
+      building: 'Test',
+      wing: 'Test',
+      level: 'Test',
+      status: DepartementStatus.ACTIVE,
     });
 
     const hash = await argon2.hash('password');


### PR DESCRIPTION
This pull request updates the test setup in `server/jest.setup.ts` to include additional fields for the `Departement` entity and introduces the `DepartementStatus` enum for setting the status of a department during test initialization.

### Updates to test setup:

* [`server/jest.setup.ts`](diffhunk://#diff-35be73996c46b4ad41b23a778e199e48f6d74e24b0a788d54733928c95165539R14-R17): Added `building`, `wing`, `level`, and `status` fields to the `Departement` initialization in the `beforeAll` hook. The `status` field uses the `DepartementStatus.ACTIVE` enum value.
* [`server/jest.setup.ts`](diffhunk://#diff-35be73996c46b4ad41b23a778e199e48f6d74e24b0a788d54733928c95165539L5-R5): Imported `DepartementStatus` from `departement.entity` to support the new `status` field.