### PR TITLE
chore(server/middleware/auth): Add auth middleware

### DIFF
--- a/server/src/middlewares/auth.middleware.ts
+++ b/server/src/middlewares/auth.middleware.ts
@@ -1,0 +1,45 @@
+import { MiddlewareFn } from 'type-graphql';
+import { User } from '../entities/user.entity';
+import { verifyToken } from '../utils/jwt.utils';
+import { IncomingMessage, ServerResponse } from 'http';
+
+export const AuthMiddleware: MiddlewareFn<{
+  req: IncomingMessage;
+  res: ServerResponse<IncomingMessage>;
+  user?: User;
+}> = async ({ context }, next) => {
+  try {
+    const { req } = context;
+    const cookie = req.headers.cookie;
+
+    if (cookie) {
+      const cookies = cookie.split(';').reduce(
+        (acc, current) => {
+          const [key, value] = current.trim().split('=');
+          acc[key] = value;
+          return acc;
+        },
+        {} as Record<string, string>,
+      );
+
+      const token = cookies['token'];
+
+      if (token) {
+        const decoded = verifyToken(token);
+        const user = await User.findOne({
+          where: { id: decoded.id },
+          relations: ['departement'],
+        });
+
+        if (user) {
+          context.user = user;
+        }
+      }
+    }
+
+    return next();
+  } catch (error) {
+    console.error('Auth middleware error:', error);
+    return next();
+  }
+};

--- a/server/src/resolvers/auth.resolver.ts
+++ b/server/src/resolvers/auth.resolver.ts
@@ -1,10 +1,11 @@
 import argon2 from 'argon2';
-import { Resolver, Mutation, Arg, Ctx, Query } from 'type-graphql';
-import { Response, Request } from 'express';
+import { Resolver, Mutation, Arg, Ctx, Query, UseMiddleware } from 'type-graphql';
+import { Response } from 'express';
 
 import { User } from '../entities/user.entity';
 import { LoginInput, AuthResponse } from '../types/auth.type';
-import { generateToken, verifyToken } from '../utils/jwt.utils';
+import { generateToken } from '../utils/jwt.utils';
+import { AuthMiddleware } from '../middlewares/auth.middleware';
 
 @Resolver()
 export class AuthResolver {
@@ -37,38 +38,8 @@ export class AuthResolver {
   }
 
   @Query(() => User, { nullable: true })
-  async me(@Ctx() context: { req: Request }): Promise<User | null> {
-    try {
-      const cookie = context.req.headers.cookie;
-      if (!cookie) {
-        return null;
-      }
-
-      const cookies = cookie.split(';').reduce(
-        (acc, current) => {
-          const [key, value] = current.trim().split('=');
-          acc[key] = value;
-          return acc;
-        },
-        {} as Record<string, string>,
-      );
-
-      const token = cookies['token'];
-      if (!token) {
-        return null;
-      }
-
-      const decoded = verifyToken(token);
-
-      const user = await User.findOne({
-        where: { id: decoded.id },
-        relations: ['departement'],
-      });
-
-      return user;
-    } catch (error) {
-      console.error('Error verifying authentication:', error);
-      return null;
-    }
+  @UseMiddleware(AuthMiddleware)
+  async me(@Ctx() context: { user: User }): Promise<User | null> {
+    return context.user;
   }
 }


### PR DESCRIPTION
This pull request refactors the authentication logic by introducing a reusable middleware for user authentication and simplifies the `me` query in the `AuthResolver`. The key changes include the creation of an `AuthMiddleware` to handle token verification and user lookup, and the replacement of inline authentication logic in the `me` query with this middleware.

### Middleware Implementation:
* Introduced `AuthMiddleware` in `server/src/middlewares/auth.middleware.ts` to handle token extraction, verification, and user retrieval. This middleware attaches the authenticated user to the context if a valid token is provided.

### Resolver Refactoring:
* Updated `AuthResolver` in `server/src/resolvers/auth.resolver.ts` to use the newly created `AuthMiddleware` for the `me` query, replacing the inline authentication logic. This simplifies the resolver and ensures consistent authentication handling.
* Added the `UseMiddleware` decorator to the `me` query in `AuthResolver` to apply the `AuthMiddleware`.

### Code Cleanup:
* Removed unused imports (`verifyToken`) and redundant inline authentication logic from `server/src/resolvers/auth.resolver.ts`. [[1]](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L2-R8) [[2]](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L40-R43)