### PR TITLE
chore(server/schema): Add 'authChecker' key to schema to check for roles

### DIFF
--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -8,5 +8,19 @@ import { CityResolver } from './resolvers/city.resolver';
 export default async function createSchema() {
   return await buildSchema({
     resolvers: [AuthResolver, DepartementResolver, PatientResolver, CityResolver],
+    authChecker: async ({ context }, roles) => {
+      if (roles.length === 0) {
+        return !!context.user;
+      }
+
+      if (!context.user) {
+        console.error(
+          'User not found. try to check if you use the AuthMiddleware above the resolver !',
+        );
+        return false;
+      }
+
+      return roles.includes(context.user.role);
+    },
   });
 }


### PR DESCRIPTION
This pull request introduces an `authChecker` function to the `createSchema` method in `server/src/schema.ts`. The `authChecker` function is responsible for handling role-based authorization and ensuring that a user is authenticated before accessing certain resolvers.

### Key changes:

#### Authorization logic:

* Added an `authChecker` function to verify user authentication and role-based access. If no roles are specified, it checks for the presence of a user in the context. If roles are specified, it ensures the user's role matches one of the allowed roles. Additionally, it logs an error if no user is found in the context. (`[server/src/schema.tsR11-R24](diffhunk://#diff-28afa203a78af6e3985c881bac6935fd38f7180a03b67022daf3b752c5289c5dR11-R24)`)