### PR TITLE
chore(workflow/branching-naming): Add issue name in regex

### DIFF
--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -11,11 +11,11 @@ jobs:
       - name: Check branch name
         run: |
           BRANCH_NAME="${{ github.head_ref }}"
-          PATTERN="^(feature|bugfix|hotfix|chore|experiment|dev)/[a-zA-Z0-9_-]+(/[0-9]+)?$|^dev$"
+          PATTERN="^(feature|bugfix|hotfix|chore|experiment|dev)/[a-zA-Z0-9_-]+(/[a-zA-Z0-9_-]+)?$|^dev$"
           
           if [[ ! $BRANCH_NAME =~ $PATTERN ]]; then
             echo "❌ Branch name '$BRANCH_NAME' does not follow the convention:"
-            echo "   <type>/<name>/<issue_ID> or <type>/<name> or dev"
+            echo "   <type>/<name>/<issue> or <type>/<name> or dev"
             echo "   where <type> is one of: feature, bugfix, hotfix, chore, experiment, dev"
             exit 1
           else


### PR DESCRIPTION
This pull request updates the branch naming validation in the `branch-naming.yml` workflow file to allow more flexibility in branch names and clarify the naming convention in error messages.

### Workflow updates:
* Updated the branch name validation regex to allow additional flexibility in the `<issue>` portion of the branch name by permitting alphanumeric characters and underscores (`_`) instead of restricting it to numeric values. (`[.github/workflows/branch-naming.ymlL14-R18](diffhunk://#diff-18e72683915ecbfd1cf1456df60b94025e80080af366c405498d059e1601d6efL14-R18)`)
* Adjusted the error message to reflect the updated naming convention, replacing `<issue_ID>` with `<issue>` for consistency and clarity. (`[.github/workflows/branch-naming.ymlL14-R18](diffhunk://#diff-18e72683915ecbfd1cf1456df60b94025e80080af366c405498d059e1601d6efL14-R18)`)