### PR TITLE
refactor(server/auth): Add jwt utils for dry principle

### DIFF
--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -4,23 +4,19 @@ import { PatientResolver } from './resolvers/patient.resolver';
 import { AuthResolver } from './resolvers/auth.resolver';
 import { DepartementResolver } from './resolvers/departement.resolver';
 import { CityResolver } from './resolvers/city.resolver';
+import { getUserFromToken } from './utils/jwt.utils';
 
 export default async function createSchema() {
   return await buildSchema({
     resolvers: [AuthResolver, DepartementResolver, PatientResolver, CityResolver],
     authChecker: async ({ context }, roles) => {
-      if (roles.length === 0) {
-        return !!context.user;
-      }
+      const user = await getUserFromToken(context.req.headers.cookie);
 
-      if (!context.user) {
-        console.error(
-          'User not found. try to check if you use the AuthMiddleware above the resolver !',
-        );
-        return false;
-      }
+      if (roles.length === 0) return !!user;
 
-      return roles.includes(context.user.role);
+      if (!user) return false;
+
+      return roles.includes(user.role);
     },
   });
 }

--- a/server/src/utils/jwt.utils.ts
+++ b/server/src/utils/jwt.utils.ts
@@ -22,3 +22,29 @@ export const verifyToken = (token: string): { id: number; email: string; role: s
     throw new Error('Invalid token');
   }
 };
+
+export const parseCookie = (cookie: string): Record<string, string> =>
+  cookie.split(';').reduce(
+    (acc, current) => {
+      const [key, value] = current.trim().split('=');
+      acc[key] = value;
+      return acc;
+    },
+    {} as Record<string, string>,
+  );
+
+export const getUserFromToken = async (cookie: string): Promise<User | null> => {
+  const cookies = parseCookie(cookie);
+  const token = cookies['token'];
+
+  if (!token) {
+    throw new Error('No token found');
+  }
+
+  const decoded = verifyToken(token);
+  const user = await User.findOne({ where: { id: decoded.id } });
+  if (!user) {
+    throw new Error('User not found');
+  }
+  return user;
+};


### PR DESCRIPTION
This pull request refactors authentication logic by introducing a new utility function, `getUserFromToken`, to simplify and centralize token parsing and user retrieval. The most important changes include replacing inline token parsing with the new utility function, updating the `AuthMiddleware` and `authChecker` to use this function, and adding the `parseCookie` helper.

### Refactoring Authentication Logic:

* **Centralized Token Parsing and User Retrieval**: Added `getUserFromToken` and `parseCookie` functions in `server/src/utils/jwt.utils.ts` to parse cookies and retrieve the user based on the token. This centralizes and simplifies the logic for handling authentication.

* **Updated `AuthMiddleware`**: Replaced inline token parsing and user retrieval logic with the `getUserFromToken` utility function in `server/src/middlewares/auth.middleware.ts`. This reduces redundancy and improves code clarity. [[1]](diffhunk://#diff-37b10b68ac078376366488bbcaa7e10a8b5ace68436576b301cd867e2d63d181L3-R3) [[2]](diffhunk://#diff-37b10b68ac078376366488bbcaa7e10a8b5ace68436576b301cd867e2d63d181L12-L38)

* **Refactored `authChecker` in Schema**: Modified the `authChecker` function in `server/src/schema.ts` to use `getUserFromToken` for user retrieval, ensuring consistent behavior across the application.