### PR TITLE
fix(src/util/jwt): Add relation for department in jwt utils

### DIFF
--- a/server/src/utils/jwt.utils.ts
+++ b/server/src/utils/jwt.utils.ts
@@ -48,7 +48,7 @@ export const getUserFromToken = async (cookie: string): Promise<User | null> => 
   }
 
   const decoded = verifyToken(token);
-  const user = await User.findOne({ where: { id: decoded.id } });
+  const user = await User.findOne({ where: { id: decoded.id }, relations: { departement: true } });
   if (!user) {
     throw new Error('User not found');
   }


### PR DESCRIPTION
This pull request includes a small but important change to the `getUserFromToken` function in `server/src/utils/jwt.utils.ts`. The change ensures that when retrieving a user from the database, the associated `departement` relation is also fetched.

* [`server/src/utils/jwt.utils.ts`](diffhunk://#diff-96fe50b39dd0ca7d21c8ecc889eea92cfbfd17b674b2946da19cb75bf114c4f8L51-R51): Updated the `User.findOne` query to include the `departement` relation when fetching a user by their ID.