### PR TITLE
test(server/auth/me): Add test for the 'me' resolver

### DIFF
--- a/server/src/utils/jwt.utils.ts
+++ b/server/src/utils/jwt.utils.ts
@@ -20,13 +20,8 @@ export const generateToken = (user: TokenPayload): string => {
 };
 
 export const verifyToken = (token: string): { id: number; email: string; role: string } => {
-  try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'default_secret_key');
-    return decoded as { id: number; email: string; role: string };
-  } catch (error) {
-    console.error(error);
-    throw new Error('Invalid token');
-  }
+  const decoded = jwt.verify(token, process.env.JWT_SECRET || 'default_secret_key');
+  return decoded as { id: number; email: string; role: string };
 };
 
 export const parseCookie = (cookie: string): Record<string, string> =>


### PR DESCRIPTION
This pull request introduces a new GraphQL query for retrieving the authenticated user's details (`meQuery`), adds corresponding test cases to validate its behavior under various conditions, and removes error handling from the `verifyToken` utility function. Below are the key changes grouped by theme:

### GraphQL Query and Tests
* Added a new GraphQL query, `meQuery`, to fetch the authenticated user's details (`id`, `email`, `firstname`, `lastname`, and `role`) in `server/src/tests/auth.test.ts`.
* Introduced three test cases to validate the `meQuery` functionality:
  - Returns the authenticated user's data when a valid token is provided.
  - Returns `null` when no token is provided.
  - Returns `null` when an invalid token is provided.

### Utility Function Update
* Removed error handling from the `verifyToken` function in `server/src/utils/jwt.utils.ts`, which now assumes the caller will handle invalid tokens. This simplifies the function but shifts responsibility for error handling to the caller.