### PR TITLE
feat: Add agent resolver

### DIFF
--- a/server/src/resolvers/agent.resolver.ts
+++ b/server/src/resolvers/agent.resolver.ts
@@ -1,0 +1,45 @@
+import { Resolver, Query, Arg, Authorized } from 'type-graphql';
+import { Appointment, AppointmentStatus } from '../entities/appointment.entity';
+import { UserRole } from '../entities/user.entity';
+import { Between } from 'typeorm';
+
+@Resolver()
+export class AgentResolver {
+  @Query(() => [Appointment])
+  @Authorized([UserRole.AGENT, UserRole.ADMIN])
+  async getUpcomingAppointmentsByPatientAndDepartment(
+    @Arg('socialNumber', { nullable: true }) socialNumber?: string,
+    @Arg('departmentId', { nullable: true }) departmentId?: number,
+  ): Promise<Appointment[]> {
+    if (!socialNumber && !departmentId) {
+      throw new Error('Either socialNumber or departmentId must be provided');
+    }
+
+    const now = new Date();
+    const thirtyMinutesLater = new Date(now.getTime() + 30 * 60 * 1000);
+
+    const where: {
+      status: AppointmentStatus;
+      start_time: ReturnType<typeof Between<Date>>;
+      patient?: { social_number: string };
+      departement?: { id: number };
+    } = {
+      status: AppointmentStatus.CONFIRMED,
+      start_time: Between<Date>(now, thirtyMinutesLater),
+    };
+
+    if (socialNumber) {
+      where.patient = { social_number: socialNumber };
+    }
+
+    if (departmentId) {
+      where.departement = { id: departmentId };
+    }
+
+    return Appointment.find({
+      where: where,
+      relations: ['patient', 'doctor', 'departement', 'appointmentType'],
+      order: { start_time: 'ASC' },
+    });
+  }
+}

--- a/server/src/resolvers/agent.resolver.ts
+++ b/server/src/resolvers/agent.resolver.ts
@@ -6,7 +6,7 @@ import { Between } from 'typeorm';
 @Resolver()
 export class AgentResolver {
   @Query(() => [Appointment])
-  @Authorized([UserRole.AGENT, UserRole.ADMIN])
+  @Authorized([UserRole.AGENT])
   async getUpcomingAppointmentsByPatientAndDepartment(
     @Arg('socialNumber', { nullable: true }) socialNumber?: string,
     @Arg('departmentId', { nullable: true }) departmentId?: number,

--- a/server/src/schema.ts
+++ b/server/src/schema.ts
@@ -7,8 +7,9 @@ import { CityResolver } from './resolvers/city.resolver';
 import { LogResolver } from './resolvers/log.resolver';
 import { getUserFromToken } from './utils/jwt.utils';
 import { AppointmentResolver } from './resolvers/appointment.resolver';
-import { JSONScalar } from './scalar/json.scalar';
 import { UserResolver } from './resolvers/user.resolver';
+import { AgentResolver } from './resolvers/agent.resolver';
+import { JSONScalar } from './scalar/json.scalar';
 
 export default async function createSchema() {
   return await buildSchema({
@@ -20,6 +21,7 @@ export default async function createSchema() {
       AppointmentResolver,
       LogResolver,
       UserResolver,
+      AgentResolver,
     ],
     validate: true,
     authChecker: async ({ context }, roles) => {


### PR DESCRIPTION
This pull request introduces a new `AgentResolver` to handle queries related to upcoming appointments filtered by patient and department. It also integrates the new resolver into the GraphQL schema. Below are the key changes:

### Addition of `AgentResolver`:

* **New resolver implementation**: Added `AgentResolver` in `server/src/resolvers/agent.resolver.ts` to provide a `getUpcomingAppointmentsByPatientAndDepartment` query. This query retrieves upcoming confirmed appointments within the next 30 minutes, filtered by either `socialNumber` or `departmentId`. It includes relations like `patient`, `doctor`, `departement`, and `appointmentType` for richer data.

### Integration into the GraphQL schema:

* **Schema import update**: Added `AgentResolver` to the imports in `server/src/schema.ts`.
* **Resolver registration**: Registered `AgentResolver` in the `buildSchema` function to make it available in the GraphQL API.