### PR TITLE
fix(docker-compose): Update service dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - "5173:5173"
     depends_on:
-      - server
+      - codegen
 
   server:
     build:


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to modify service dependencies. The key change replaces the dependency on `server` with a dependency on `codegen`.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L18-R18): Updated the `services` configuration to replace `depends_on: server` with `depends_on: codegen`, ensuring the `codegen` service is started before the current service.