### PR TITLE
refactor(auth): remove token from login response

### DIFF
--- a/server/src/resolvers/auth.resolver.ts
+++ b/server/src/resolvers/auth.resolver.ts
@@ -37,7 +37,7 @@ export class AuthResolver {
       `token=${token}; HttpOnly; Secure; Max-Age=${1 * 24 * 60 * 60 * 1000}`,
     );
 
-    return { token, user };
+    return { user };
   }
 
   @Query(() => User, { nullable: true })

--- a/server/src/tests/auth.test.ts
+++ b/server/src/tests/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, jest, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeAll, jest, afterEach, afterAll } from '@jest/globals';
 import { graphql, GraphQLSchema, print } from 'graphql';
 import { gql } from 'graphql-tag';
 
@@ -10,7 +10,6 @@ import { generateToken } from '../utils/jwt.utils';
 const loginMutation = gql`
   mutation Mutation($input: LoginInput!) {
     login(input: $input) {
-      token
       user {
         email
       }
@@ -49,7 +48,6 @@ const meQuery = gql`
 
 type LoginResponse = {
   login: {
-    token: string;
     user: {
       email: string;
     };
@@ -78,6 +76,8 @@ describe('Auth', () => {
   let doctorToken: string;
 
   beforeAll(async () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+
     schema = await createSchema();
 
     const departement = await Departement.findOne({ where: { label: 'Test' } });
@@ -98,6 +98,10 @@ describe('Auth', () => {
 
   afterEach(async () => {
     await User.delete({ email: 'newuser@test.com' });
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
   });
 
   it('should be able to login', async () => {
@@ -123,7 +127,6 @@ describe('Auth', () => {
     const data = result.data as unknown as LoginResponse;
 
     expect(data.login).toBeDefined();
-    expect(data.login.token).toBeDefined();
     expect(data.login.user).toBeDefined();
   });
 

--- a/server/src/types/auth.type.ts
+++ b/server/src/types/auth.type.ts
@@ -12,9 +12,6 @@ export class LoginInput {
 
 @ObjectType()
 export class AuthResponse {
-  @Field()
-  token: string;
-
   @Field(() => User)
   user: User;
 }


### PR DESCRIPTION
This pull request removes the `token` field from the authentication response, simplifying the API and its related tests. The most important changes include updates to the resolver, test cases, and type definitions to reflect the removal of the `token` field.

### Authentication API Changes:
* [`server/src/resolvers/auth.resolver.ts`](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L40-R40): Modified the `login` mutation to return only the `user` object, removing the `token` from the response.

### Test Updates:
* `server/src/tests/auth.test.ts`: 
  - Updated the `login` mutation and its associated test cases to exclude the `token` field. [[1]](diffhunk://#diff-1b53dda00395d698427ec976650d851c83116be38a2c0b1ef2676149b7047505L13) [[2]](diffhunk://#diff-1b53dda00395d698427ec976650d851c83116be38a2c0b1ef2676149b7047505L52) [[3]](diffhunk://#diff-1b53dda00395d698427ec976650d851c83116be38a2c0b1ef2676149b7047505L126)
  - Added `jest.spyOn` to suppress `console.error` during tests and restored all mocks in an `afterAll` hook to clean up after tests. [[1]](diffhunk://#diff-1b53dda00395d698427ec976650d851c83116be38a2c0b1ef2676149b7047505R79-R80) [[2]](diffhunk://#diff-1b53dda00395d698427ec976650d851c83116be38a2c0b1ef2676149b7047505R103-R106)

### Type Definition Updates:
* [`server/src/types/auth.type.ts`](diffhunk://#diff-d3e6e3db1b7ab85c633012bd21adcf8b04ee0e64c1eac04eaa60d523821c3729L15-L17): Removed the `token` field from the `AuthResponse` class, ensuring the type aligns with the updated API response.