### PR TITLE
feat(schema): add GraphQL query for upcoming appointments

### DIFF
--- a/client/src/schemas/agent.schema.ts
+++ b/client/src/schemas/agent.schema.ts
@@ -1,0 +1,28 @@
+import { gql } from '@apollo/client';
+
+export const GET_UPCOMING_APPOINTMENTS = gql`
+  query GetUpcomingAppointmentsByPatientAndDepartment($input: AppointmentInput!) {
+    getUpcomingAppointmentsByPatientAndDepartment(input: $input) {
+      id
+      start_time
+      status
+      patient {
+        firstname
+        lastname
+        social_number
+      }
+      doctor {
+        firstname
+        lastname
+      }
+      departement {
+        id
+        label
+      }
+      appointmentType {
+        id
+        reason
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This pull request introduces a new GraphQL query to fetch upcoming appointments based on patient and department data. The query includes detailed information about the appointment, patient, doctor, department, and appointment type.

Key addition:

* [`client/src/schemas/agent.schema.ts`](diffhunk://#diff-53d22e7ca013ee23cf950782544cdee95384f32c5ab714d5fc101c23fee36104R1-R28): Added the `GET_UPCOMING_APPOINTMENTS` GraphQL query to retrieve upcoming appointments with fields such as `id`, `start_time`, `status`, patient and doctor details, department information, and appointment type.