### PR TITLE
Chore/deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
             git pull origin main
 
             echo "🛑 Arrêt des conteneurs existants..."
-            docker compose down -v
+            docker compose down
 
             echo "🔨 Construction et démarrage des nouveaux conteneurs..."
             docker compose up --build -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Continuous Deployment
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to VPS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USERNAME }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: ${{ secrets.VPS_PORT || 22 }}
+          script: |
+            cd /home/ubuntu/CDA-Projet-2-Team-2
+
+            echo "📂 Dossier actuel: $(pwd)"
+
+            echo "🔄 Récupération des dernières modifications..."
+            git pull origin main
+
+            echo "🛑 Arrêt des conteneurs existants..."
+            docker compose down -v
+
+            echo "🔨 Construction et démarrage des nouveaux conteneurs..."
+            docker compose up --build -d
+
+            echo "🧹 Nettoyage des images Docker inutilisées..."
+            docker image prune -f
+
+            echo "✅ Statut des conteneurs:"
+            docker compose ps
+
+            echo "🎉 Déploiement terminé!"


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous deployment to a VPS. The workflow automates the process of pulling the latest changes, rebuilding Docker containers, and cleaning up unused Docker images.

### Continuous Deployment Workflow:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R1-R41): Added a new workflow named `Continuous Deployment`. It triggers on pushes to the `main` branch or via manual dispatch. The workflow uses the `appleboy/ssh-action` to connect to a VPS, pull the latest changes from the `main` branch, stop existing Docker containers, rebuild and start new containers, and clean up unused Docker images.