### PR TITLE
refactor(auth): return user object without password

### DIFF
--- a/server/src/resolvers/auth.resolver.ts
+++ b/server/src/resolvers/auth.resolver.ts
@@ -37,7 +37,11 @@ export class AuthResolver {
       `token=${token}; HttpOnly; Secure; Max-Age=${1 * 24 * 60 * 60 * 1000}`,
     );
 
-    return { user };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { password, ...userWithoutPassword } = user;
+    const plainUser = Object.assign(new User(), userWithoutPassword);
+
+    return { user: plainUser };
   }
 
   @Query(() => User, { nullable: true })


### PR DESCRIPTION
This pull request modifies the `AuthResolver` class in the `server/src/resolvers/auth.resolver.ts` file to enhance security by excluding sensitive user information from the returned object.

Security improvement:

* [`server/src/resolvers/auth.resolver.ts`](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22L40-R44): Updated the `AuthResolver` class to exclude the `password` field from the user object before returning it. A new `User` instance is created with the remaining user properties to ensure sensitive data is not exposed.