### PR TITLE
feat(server/eslint): add rules for unused variables in TypeScript

### DIFF
--- a/server/eslint.config.mjs
+++ b/server/eslint.config.mjs
@@ -34,6 +34,15 @@ export default [
           allowTernary: true,
         },
       ],
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
     },


### PR DESCRIPTION
This pull request introduces a new ESLint rule to the `server/eslint.config.mjs` file, enhancing code quality by enforcing stricter checks on unused variables.

Code quality improvements:

* [`server/eslint.config.mjs`](diffhunk://#diff-cd26118cb2e42a5ca5a6236ddc92ec983d5825b83672840dbed6d41b72cd41f7R37-R45): Added the `@typescript-eslint/no-unused-vars` rule with configurations to ignore variables, arguments, caught errors, and destructured array elements prefixed with `_`. This ensures unused variables are flagged as errors while allowing intentional unused variables to be prefixed for clarity.