### PR TITLE
feat(auth/logout): Add logout backend

### DIFF
--- a/client/src/contexts/AuthContext.ts
+++ b/client/src/contexts/AuthContext.ts
@@ -7,7 +7,7 @@ export type AuthContextType = {
   isLoading: boolean;
   error: string | null;
   login: (email: string, password: string) => Promise<string | undefined>;
-  logout: () => void;
+  logout: () => Promise<void>;
 };
 
 export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/client/src/contexts/auth.context.tsx
+++ b/client/src/contexts/auth.context.tsx
@@ -56,16 +56,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setError(null);
 
     try {
-      // Appeler la mutation logout côté serveur
       await logoutMutation();
 
-      // Effacer l'état utilisateur côté client
       setUser(null);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Une erreur est survenue lors de la déconnexion',
       );
-      // Même en cas d'erreur, on efface l'état utilisateur côté client
       setUser(null);
     } finally {
       setIsLoading(false);

--- a/client/src/schemas/auth.schema.ts
+++ b/client/src/schemas/auth.schema.ts
@@ -33,3 +33,9 @@ export const ME_QUERY = gql`
     }
   }
 `;
+
+export const LOGOUT_MUTATION = gql`
+  mutation Logout {
+    logout
+  }
+`;

--- a/server/src/resolvers/auth.resolver.ts
+++ b/server/src/resolvers/auth.resolver.ts
@@ -41,6 +41,17 @@ export class AuthResolver {
     return { user: plainUser };
   }
 
+  @Mutation(() => Boolean)
+  @UseMiddleware(AuthMiddleware)
+  async logout(@Ctx() context: { res: Response }): Promise<boolean> {
+    context.res.setHeader(
+      'Set-Cookie',
+      'token=; HttpOnly; Secure; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT',
+    );
+
+    return true;
+  }
+
   @Query(() => User, { nullable: true })
   @UseMiddleware(AuthMiddleware)
   async me(@Ctx() context: { user: User }): Promise<User | null> {


### PR DESCRIPTION
This pull request introduces a logout functionality across the client and server, ensuring a seamless user experience for signing out. The changes include updates to the client-side `AuthContext` and `AuthProvider`, addition of a GraphQL mutation for logout, and implementation of the logout resolver on the server.

### Client-side changes:

* **Updated `logout` method in `AuthContext`:** Changed the `logout` method to return a `Promise<void>` to accommodate asynchronous operations. (`client/src/contexts/AuthContext.ts`, [client/src/contexts/AuthContext.tsL10-R10](diffhunk://#diff-e57ddc15686135d9042a223520519a9718c344e29ef29403709a9e2f599189c5L10-R10))
* **Integrated `logoutMutation` in `AuthProvider`:** Added `logoutMutation` from GraphQL and implemented it within the `logout` method, handling loading states, error messages, and resetting the user context. (`client/src/contexts/auth.context.tsx`, [[1]](diffhunk://#diff-09daabaaa3f0e7d7b97a11227d551cc94855c3a154eb49607ca9db0937102291L2-R2) [[2]](diffhunk://#diff-09daabaaa3f0e7d7b97a11227d551cc94855c3a154eb49607ca9db0937102291R11) [[3]](diffhunk://#diff-09daabaaa3f0e7d7b97a11227d551cc94855c3a154eb49607ca9db0937102291L53-R70)

### GraphQL schema changes:

* **Added `LOGOUT_MUTATION`:** Defined the `LOGOUT_MUTATION` in the GraphQL schema to support the logout operation. (`client/src/schemas/auth.schema.ts`, [client/src/schemas/auth.schema.tsR36-R41](diffhunk://#diff-4fcb76563423698b335189575cc08ab27244ad077cb2e03805a0c9d86c534cd4R36-R41))

### Server-side changes:

* **Implemented `logout` resolver:** Added a `logout` mutation in the `AuthResolver` to clear the authentication token from cookies, ensuring secure and proper logout functionality. (`server/src/resolvers/auth.resolver.ts`, [server/src/resolvers/auth.resolver.tsR44-R54](diffhunk://#diff-984c625c00e3f325b06290be023448bfb255cf32da2a64f4c40d075a641c7a22R44-R54))