### PR TITLE
feat(LinkButton): update to display multiple link buttons

### DIFF
--- a/client/src/components/layout/LinkButton.tsx
+++ b/client/src/components/layout/LinkButton.tsx
@@ -5,26 +5,34 @@ import { getPathFromRole } from '@/utils/getPathFromRole';
 export function LinkButton() {
   const { user } = useAuth();
   const location = useLocation();
-  let linkButton = null;
+  let linkButtons = null;
 
   const rolePath = getPathFromRole(user?.role || '');
 
   if (location.pathname === '/admin/users') {
-    linkButton = { title: 'Gérer les logs', link: '/admin/logs' };
+    linkButtons = [
+      { title: 'Gérer les logs', link: '/admin/logs' },
+      { title: 'Gérer les services', link: '/admin/department' },
+    ];
   } else if (location.pathname !== rolePath) {
-    linkButton = { title: 'Tableau de bord', link: getPathFromRole(user?.role || '') };
+    linkButtons = [{ title: 'Tableau de bord', link: getPathFromRole(user?.role || '') }];
   }
 
-  if (!linkButton) {
+  if (!linkButtons) {
     return null;
   }
 
   return (
-    <Link
-      to={linkButton.link}
-      className="bg-blue text-white px-4 py-2 rounded-md hover:bg-blue/90 transition-colors"
-    >
-      {linkButton.title}
-    </Link>
+    <div className="flex gap-3">
+      {linkButtons.map(button => (
+        <Link
+          key={button.title}
+          to={button.link}
+          className="bg-blue text-white px-4 py-2 rounded-md hover:bg-blue/90 transition-colors"
+        >
+          {button.title}
+        </Link>
+      ))}
+    </div>
   );
 }


### PR DESCRIPTION
This pull request updates the `LinkButton` component in `client/src/components/layout/LinkButton.tsx` to support rendering multiple buttons instead of a single button. The changes improve flexibility and usability by allowing multiple links to be displayed based on the user's role and current location.

### Changes to `LinkButton` component:

* Replaced the `linkButton` variable with `linkButtons`, which is now an array to accommodate multiple button configurations.
* Updated the logic to populate `linkButtons` with multiple entries when the user is on the `/admin/users` path, adding links for managing logs and services.
* Modified the JSX to iterate over the `linkButtons` array and render a `Link` component for each button, ensuring proper styling and unique keys for each button.