### PR TITLE
fix(SearchSection): reset department search term when toggling dropdown

### DIFF
--- a/client/src/components/agent/SearchSection.tsx
+++ b/client/src/components/agent/SearchSection.tsx
@@ -111,7 +111,10 @@ export default function SearchSection({
           ) : (
             <div className="relative">
               <button
-                onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+                onClick={() => {
+                  setIsDropdownOpen(!isDropdownOpen);
+                  setDepartmentSearchTerm('');
+                }}
                 className="w-full pl-12 pr-10 py-3 border border-borderColor rounded-xl focus:outline-none focus:ring-2 focus:ring-blue/20 focus:border-blue transition-all cursor-pointer bg-white flex items-center justify-between"
               >
                 <span className={selectedDepartment ? 'text-gray-900' : 'text-gray-400'}>


### PR DESCRIPTION
This pull request includes a minor update to the `SearchSection` component to improve the behavior of the dropdown menu. Specifically, it ensures that the `departmentSearchTerm` is reset whenever the dropdown is toggled.

* [`client/src/components/agent/SearchSection.tsx`](diffhunk://#diff-8626845ee2b97d6c8ee1986e4c0e3a649fe1c8ffa7eda4d5126d0425dfbf8cceL114-R117): Updated the `onClick` handler for the dropdown button to reset `departmentSearchTerm` to an empty string when toggling the dropdown menu.